### PR TITLE
feat: add numeronym funcs

### DIFF
--- a/numeronym.go
+++ b/numeronym.go
@@ -1,0 +1,50 @@
+package stringo
+
+import "strconv"
+
+// Numeronym converts a string into its numeronym form.
+//
+// A numeronym is a word where the middle letters are replaced by the count of those letters.
+// For example, "kubernetes" becomes "k8s" because there are 8 letters between 'k' and 's'.
+// If the input string has less than 3 characters, it is returned unchanged.
+//
+// This function correctly handles Unicode strings.
+//
+// If you require better performance and are sure the input is ASCII, consider using NumeronymASCII().
+func Numeronym(s string) string {
+	rr := []rune(s)
+	n := len(rr)
+	if n < 3 {
+		return s
+	}
+	num := []rune(strconv.Itoa(n - 2))
+	res := make([]rune, len(num)+2)
+	res[0] = rr[0]
+	for i, r := range num {
+		res[i+1] = r
+	}
+	res[len(res)-1] = rr[n-1]
+	return string(res)
+}
+
+// NumeronymASCII converts an ASCII string into its numeronym form.
+//
+// A numeronym is a word where the middle letters are replaced by the count of those letters.
+// For example, "kubernetes" becomes "k8s" because there are 8 letters between 'k' and 's'.
+// If the input string has less than 3 characters, it is returned unchanged.
+//
+// This function is optimized for ASCII strings and may not handle Unicode characters correctly.
+//
+// If you need to handle Unicode strings, consider using Numeronym().
+func NumeronymASCII(s string) string {
+	n := len(s)
+	if n < 3 {
+		return s
+	}
+	num := []byte(strconv.Itoa(n - 2))
+	res := make([]byte, 0, len(num)+2)
+	res = append(res, s[0])
+	res = append(res, num...)
+	res = append(res, s[n-1])
+	return string(res)
+}

--- a/numeronym_test.go
+++ b/numeronym_test.go
@@ -1,0 +1,257 @@
+package stringo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNumeronymASCII(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "kubernetes",
+			args: args{
+				s: "kubernetes",
+			},
+			want: "k8s",
+		},
+		{
+			name: "cat",
+			args: args{
+				s: "cat",
+			},
+			want: "c1t",
+		},
+		{
+			name: "INTERNATIONALIZATION",
+			args: args{
+				s: "INTERNATIONALIZATION",
+			},
+			want: "I18N",
+		},
+		{
+			name: "accessibility",
+			args: args{
+				s: "accessibility",
+			},
+			want: "a11y",
+		},
+		{
+			name: "localization",
+			args: args{
+				s: "localization",
+			},
+			want: "l10n",
+		},
+		{
+			name: "to",
+			args: args{
+				s: "to",
+			},
+			want: "to",
+		},
+		{
+			name: "t",
+			args: args{
+				s: "t",
+			},
+			want: "t",
+		},
+		{
+			name: "empty",
+			args: args{
+				s: "",
+			},
+			want: "",
+		},
+		{
+			name: "post-office",
+			args: args{
+				s: "post-office",
+			},
+			want: "p9e",
+		},
+		{
+			name: "google.com",
+			args: args{
+				s: "google.com",
+			},
+			want: "g8m",
+		},
+		{
+			name: "-kebab-case-",
+			args: args{
+				s: "-kebab-case-",
+			},
+			want: "-10-",
+		},
+		{
+			name: "-123",
+			args: args{
+				s: "-123",
+			},
+			want: "-23",
+		},
+		{
+			name: "Supercalifragilisticexpialidocious",
+			args: args{
+				s: "Supercalifragilisticexpialidocious",
+			},
+			want: "S32s",
+		},
+		{
+			name: "мир",
+			args: args{
+				s: "мир",
+			},
+			want: "\xd04\x80",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NumeronymASCII(tt.args.s)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNumeronym(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "kubernetes",
+			args: args{
+				s: "kubernetes",
+			},
+			want: "k8s",
+		},
+		{
+			name: "cat",
+			args: args{
+				s: "cat",
+			},
+			want: "c1t",
+		},
+		{
+			name: "INTERNATIONALIZATION",
+			args: args{
+				s: "INTERNATIONALIZATION",
+			},
+			want: "I18N",
+		},
+		{
+			name: "accessibility",
+			args: args{
+				s: "accessibility",
+			},
+			want: "a11y",
+		},
+		{
+			name: "localization",
+			args: args{
+				s: "localization",
+			},
+			want: "l10n",
+		},
+		{
+			name: "to",
+			args: args{
+				s: "to",
+			},
+			want: "to",
+		},
+		{
+			name: "t",
+			args: args{
+				s: "t",
+			},
+			want: "t",
+		},
+		{
+			name: "empty",
+			args: args{
+				s: "",
+			},
+			want: "",
+		},
+		{
+			name: "post-office",
+			args: args{
+				s: "post-office",
+			},
+			want: "p9e",
+		},
+		{
+			name: "google.com",
+			args: args{
+				s: "google.com",
+			},
+			want: "g8m",
+		},
+		{
+			name: "-kebab-case-",
+			args: args{
+				s: "-kebab-case-",
+			},
+			want: "-10-",
+		},
+		{
+			name: "-123",
+			args: args{
+				s: "-123",
+			},
+			want: "-23",
+		},
+		{
+			name: "Supercalifragilisticexpialidocious",
+			args: args{
+				s: "Supercalifragilisticexpialidocious",
+			},
+			want: "S32s",
+		},
+		{
+			name: "мир",
+			args: args{
+				s: "мир",
+			},
+			want: "м1р",
+		},
+		{
+			name: "chinese",
+			args: args{
+				s: "国际化",
+			},
+			want: "国1化",
+		},
+		{
+			name: "emoji",
+			args: args{
+				s: "😀😃😄😁😆😅😂🤣😊😇",
+			},
+			want: "😀8😇",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Numeronym(tt.args.s)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
- Added `Numeronym()` converts any string (in Unicode) to its numeronym form
- Added `NumeronymASCII()` converts only ASCII strings to its numeronym form to get more performance