### PR TITLE
feat: add Between string helper with tests

### DIFF
--- a/common.go
+++ b/common.go
@@ -32,19 +32,24 @@ func SplitFunc(s string, cond func(rune, int) bool, incSep bool) []string {
 }
 
 // Between returns substring placed between two provided symbols.
+//
+//   - s: the source string to search in.
+//   - left: the left delimiter to search for.
+//   - right: the right delimiter to search for.
+//
+// Example:
+//
+//	Between("Hello, World!", ",", "!") -> " World"
 func Between(s, left, right string) string {
 	leftIdx := strings.Index(s, left)
 	if leftIdx == -1 {
 		return ""
 	}
-
 	contentStart := leftIdx + len(left)
-
 	rightIdx := strings.Index(s[contentStart:], right)
 	if rightIdx == -1 {
 		return ""
 	}
 	rightAbsIdx := contentStart + rightIdx
-
 	return s[contentStart:rightAbsIdx]
 }

--- a/common.go
+++ b/common.go
@@ -46,6 +46,9 @@ func Between(s, left, right string) string {
 		return ""
 	}
 	contentStart := leftIdx + len(left)
+	if right == "" {
+		return s[contentStart:]
+	}
 	rightIdx := strings.Index(s[contentStart:], right)
 	if rightIdx == -1 {
 		return ""

--- a/common.go
+++ b/common.go
@@ -30,3 +30,21 @@ func SplitFunc(s string, cond func(rune, int) bool, incSep bool) []string {
 
 	return ss
 }
+
+// Between returns substring placed between two provided symbols.
+func Between(s, left, right string) string {
+	leftIdx := strings.Index(s, left)
+	if leftIdx == -1 {
+		return ""
+	}
+
+	contentStart := leftIdx + len(left)
+
+	rightIdx := strings.Index(s[contentStart:], right)
+	if rightIdx == -1 {
+		return ""
+	}
+	rightAbsIdx := contentStart + rightIdx
+
+	return s[contentStart:rightAbsIdx]
+}

--- a/common_test.go
+++ b/common_test.go
@@ -75,3 +75,92 @@ func TestSplitFunc(t *testing.T) {
 		})
 	}
 }
+
+func TestBetween(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		s     string
+		left  string
+		right string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "basic case",
+			args: args{
+				s:     "hello [world]!",
+				left:  "[",
+				right: "]",
+			},
+			want: "world",
+		},
+		{
+			name: "left missing",
+			args: args{
+				s:     "hello world",
+				left:  "[",
+				right: "]",
+			},
+			want: "",
+		},
+		{
+			name: "right missing",
+			args: args{
+				s:     "hello [world",
+				left:  "[",
+				right: "]",
+			},
+			want: "",
+		},
+		{
+			name: "multiple occurrences - takes first",
+			args: args{
+				s:     "a[1]b[2]",
+				left:  "[",
+				right: "]",
+			},
+			want: "1",
+		},
+		{
+			name: "mixed delimiters",
+			args: args{
+				s:     "idx: 123, val: 456",
+				left:  "idx: ",
+				right: ",",
+			},
+			want: "123",
+		},
+		{
+			name: "nested delimiters (naive scan)",
+			args: args{
+				s:     "a[b[c]d]",
+				left:  "[",
+				right: "]",
+			},
+			want: "b[c",
+		},
+		{
+			name: "empty result",
+			args: args{
+				s:     "[]",
+				left:  "[",
+				right: "]",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := Between(tt.args.s, tt.args.left, tt.args.right)
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/common_test.go
+++ b/common_test.go
@@ -160,6 +160,42 @@ func TestBetween(t *testing.T) {
 			},
 			want: "",
 		},
+		{
+			name: "from [ to end",
+			args: args{
+				s:     "hello [world]",
+				left:  "[",
+				right: "",
+			},
+			want: "world]",
+		},
+		{
+			name: "from start to ]",
+			args: args{
+				s:     "hello [world]",
+				left:  "",
+				right: "]",
+			},
+			want: "hello [world",
+		},
+		{
+			name: "empty delimiters return full string",
+			args: args{
+				s:     "some text",
+				left:  "",
+				right: "",
+			},
+			want: "some text",
+		},
+		{
+			name: "same delimiters",
+			args: args{
+				s:     "|content|",
+				left:  "|",
+				right: "|",
+			},
+			want: "content",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/common_test.go
+++ b/common_test.go
@@ -153,7 +153,7 @@ func TestBetween(t *testing.T) {
 		},
 		{
 			name: "default args",
-			args: args{},
+			args: args{}, // s="", left="", right=""
 			want: "",
 		},
 	}

--- a/common_test.go
+++ b/common_test.go
@@ -153,7 +153,11 @@ func TestBetween(t *testing.T) {
 		},
 		{
 			name: "default args",
-			args: args{}, // s="", left="", right=""
+			args: args{
+				s:     "",
+				left:  "",
+				right: "",
+			},
 			want: "",
 		},
 	}

--- a/common_test.go
+++ b/common_test.go
@@ -78,7 +78,6 @@ func TestSplitFunc(t *testing.T) {
 
 func TestBetween(t *testing.T) {
 	t.Parallel()
-
 	type args struct {
 		s     string
 		left  string
@@ -99,7 +98,7 @@ func TestBetween(t *testing.T) {
 			want: "world",
 		},
 		{
-			name: "left missing",
+			name: "left delimiter missing",
 			args: args{
 				s:     "hello world",
 				left:  "[",
@@ -108,7 +107,7 @@ func TestBetween(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "right missing",
+			name: "right delimiter missing",
 			args: args{
 				s:     "hello [world",
 				left:  "[",
@@ -135,7 +134,7 @@ func TestBetween(t *testing.T) {
 			want: "123",
 		},
 		{
-			name: "nested delimiters (naive scan)",
+			name: "nested delimiters (native scan)",
 			args: args{
 				s:     "a[b[c]d]",
 				left:  "[",
@@ -152,14 +151,17 @@ func TestBetween(t *testing.T) {
 			},
 			want: "",
 		},
+		{
+			name: "default args",
+			args: args{},
+			want: "",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
 			got := Between(tt.args.s, tt.args.left, tt.args.right)
-
 			require.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
feat: add Between string helper with tests

fix: address PR review comments

Add parameter descriptions and example to Between docstring
Remove extra newlines in function body and tests
Rename test cases for clarity (left/right delimiter missing)
Change 'naive' to 'native' in test case name
Add default args test case
test: add comment explaining default args in TestBetween

test: use explicit args in default args test case

Added more test cases